### PR TITLE
feat: login 전 홈화면 이동 수정, 시큐리티에서 제공하는 기본 로그인 화면 삭제

### DIFF
--- a/src/main/java/edu/allinone/sugang/SugangApplication.java
+++ b/src/main/java/edu/allinone/sugang/SugangApplication.java
@@ -2,8 +2,10 @@ package edu.allinone.sugang;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class) // 시큐리티에서 제공하는 로그인 기본 화면 제거
 public class SugangApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/edu/allinone/sugang/config/SecurityConfig.java
+++ b/src/main/java/edu/allinone/sugang/config/SecurityConfig.java
@@ -20,21 +20,19 @@ public class SecurityConfig {
     public PasswordEncoder passwordEncoder() {
         return NoOpPasswordEncoder.getInstance();
     }
-    // 실제 보안상 위험하긴 하지만 저희가 따로 회원가입을 구현하지 않고 DB에 값을 직접 넣어주다 보니
-    // 입력받은 비밀번호를 BCrypt 형식($2a$10$DowQ8u..)으로 인코딩한 후, 데이터 베이스에 저장할 수가 없기 때문에
-    // 일단은 평문 비밀번호(password1)로 저장하도록 설정해주었습니다.
 
     @Bean
     // 어떤 URL 경로를 보안해야 하고 어떤 경로를 보안하지 않아야 하는지 정의
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(request -> request
-                        .requestMatchers("/", "/login").permitAll()
+                        .requestMatchers("/", "/login", "/static/**", "/home").permitAll()
                         .anyRequest().authenticated()
                         // 위에서 명시한 경로를 제외한 모든 요청에 대해 인증된 사용자만 접근할 수 있도록 설정
 
                 )
                 .formLogin(login -> login
+                        .loginPage("/login") // 커스텀 로그인 페이지 설정
                         .defaultSuccessUrl("/", true)
                         // 성공 시 이동 경로 (임의로 작성, 나중에 구현 시 수정)
                         .usernameParameter("studentNumber") // 로그인 폼에서 사용자 이름 필드 이름 설정

--- a/src/main/java/edu/allinone/sugang/controller/HomeController.java
+++ b/src/main/java/edu/allinone/sugang/controller/HomeController.java
@@ -1,0 +1,20 @@
+package edu.allinone.sugang.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HomeController {
+
+    // 기본 홈 화면
+    @GetMapping({"/", "/home"})
+    public String home() {
+        return "home"; // home.html로 매핑
+    }
+
+    // 로그인 화면
+    @GetMapping("/login")
+    public String login() {
+        return "login"; // login.html로 매핑
+    }
+}

--- a/src/main/java/edu/allinone/sugang/domain/Student.java
+++ b/src/main/java/edu/allinone/sugang/domain/Student.java
@@ -10,6 +10,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(name = "student")
 public class Student {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    <p>홈화면</p>
+</body>
+</html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/test/java/edu/allinone/sugang/controller/LoginControllerTest.java
+++ b/src/test/java/edu/allinone/sugang/controller/LoginControllerTest.java
@@ -1,0 +1,16 @@
+package edu.allinone.sugang.controller;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LoginControllerTest {
+
+    @Test
+    void home() {
+    }
+
+    @Test
+    void login() {
+    }
+}


### PR DESCRIPTION
resource/templates 
- home.html, login.html 임의로 추가 (서버 실행했을 때 올바른 경로로 이동되는 지 확인 위함)

SecurityConfig
- 인증되지 않은 사용자가 접근할 수 있는 경로 구성 수정 ("/", "/login", "/static/**", "/home”)
- 스프링 시큐리티에서 제공하는 기본 로그인 페이지가 아닌 우리가 직접 로그인 페이지를 커스텀 할 수 있도록 수정 : `.loginPage("/login”)`추가

controller/HomeComtroller 추가
- 서버를 실행하면 로그인 전 기본 홈 화면으로 이동
- 로그인 요청했을 때 로그인 화면으로 이동

SugangApplication
- `@SpringBootApplication(exclude = SecurityAutoConfiguration.class)` : 시큐리티에서 제공하는 로그인 기본 화면 제거